### PR TITLE
fix inherits bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ function clone (obj) {
   return _obj
 }
 
+util.inherits(Gossip, EventEmitter)
+
 function Gossip (opts) {
   if (!(this instanceof Gossip)) { return new Gossip(opts) }
 
@@ -104,7 +106,5 @@ Gossip.prototype.stop = function () {
     clearInterval(this.interval)
   }
 }
-
-util.inherits(Gossip, EventEmitter)
 
 module.exports = Gossip


### PR DESCRIPTION
super simple PR, but helps keeping track of the discussion on a project channel.

So as a note for the future:

> Inherit the prototype methods from one constructor into another. The prototype of constructor will be set to a new object created from superConstructor.
> src: https://nodejs.org/docs/latest/api/util.html#util_util_inherits_constructor_superconstructor

Since you had the util.inherits on the bottom, you were clearing out the previous prototype and since you were declaring all the functions at the prototype level (and not as properties of the instantiated object), when it was time for the .bind to call them, they didn't exist
